### PR TITLE
feat: add CSV export functionality for monitor change log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> **Last update / Última actualización:** 2026-06-26 — `@nervill/metadelta` 0.11.10
+> **Last update / Última actualización:** 2026-06-29 — `@nervill/metadelta` 0.11.11
 
 # Metadelta Salesforce CLI Plugin
 
@@ -16,7 +16,7 @@ Metadelta is a custom Salesforce CLI plugin that offers thirteen complementary c
 * `sf metadelta access` exports aliases, captures encrypted auth URLs, and restores secure org access across Windows/Linux/WSL with an MFA checkpoint.
 * `sf metadelta security users` reads a security master matrix plus a target users list, resolves required IDs in the org, generates bulk-ready CSV files for role/PSG/group assignments, and can optionally apply changes via Bulk API or generate a current-state validation matrix via `--validate`, and compare that file against the master matrix locally via `--compare`.
 * `sf metadelta initspace` bootstraps a local Salesforce workspace by creating the base folder tree and seed project files required by this plugin.
-* `sf metadelta monitor run` starts a terminal monitor for Salesforce Core and Vlocity metadata drift using local filesystem snapshots, a local Git diff engine, optional XML/YAML scoped manifests, and a persistent JSONL change log.
+* `sf metadelta monitor run` starts a terminal monitor for Salesforce Core and Vlocity metadata drift using local filesystem snapshots, a local Git diff engine, optional XML/YAML scoped manifests, Vlocity modifier enrichment, a persistent JSONL change log, and optional CSV export.
 * `sf metadelta task record` and `sf metadelta task play` record/play Playwright-based Salesforce tasks with automatic recovery stabilizers, patched `.metadelta.*` playback, and orchestrated diagnostics.
 * `sf metadelta cleanps` extracts a focused copy of a permission set by keeping only the entries that match a fragment or appear in a curated allowlist.
 * `sf metadelta findtest` reviews Apex classes inside a local SFDX project, confirms the presence of their corresponding test classes, and can validate existing `package.xml` manifests prior to a deployment. Generated or updated manifests inherit the API version reported by the target org when available.
@@ -52,7 +52,7 @@ Created by **Nerio Villalobos** (<nervill@gmail.com>).
    ```bash
    sf plugins install github:NerioVillalobos/plugin-metadelta.git
    ```
-   Confirm installation with `sf plugins`, which should list `@nervill/metadelta 0.11.10`.
+   Confirm installation with `sf plugins`, which should list `@nervill/metadelta 0.11.11`.
 
 3. (Optional, for local development) Clone this repository and install dependencies:
    ```bash
@@ -65,7 +65,7 @@ Created by **Nerio Villalobos** (<nervill@gmail.com>).
    npm run compile
    sf plugins link .
    ```
-   Confirm installation with `sf plugins`, which should list `@nervill/metadelta 0.11.10 (link)`.
+   Confirm installation with `sf plugins`, which should list `@nervill/metadelta 0.11.11 (link)`.
 
 ### Usage
 
@@ -411,9 +411,12 @@ Options:
 | `--scope` | Metadata source to monitor: `all`, `salesforce`, or `vlocity`. | `all` |
 | `--scope-xml` | Path to a Salesforce Core `package.xml`. When present, the monitor retrieves and watches only the Core components listed in that manifest. | None |
 | `--scope-yaml` | Path to a Vlocity YAML job/manifest. When present, the monitor exports and watches only the DataPacks listed in that file. | None |
+| `--export-csv` | Path where the persistent `change-log.jsonl` should be exported as CSV when the monitor exits. The path is resolved from the directory where the command was started. | None |
 | `--once` | Run one refresh cycle and exit. Useful for validation. | `false` |
 
 The monitor first creates and enters `.metadelta/monitor/<orgAlias>/`. Inside that folder it maintains `.metadelta-monitor/`, retrieves the current metadata snapshot, initializes or reuses a local-only Git repository as the diff engine, and refreshes every five minutes. `NEXT` shows the exact next refresh time instead of repainting a countdown, and `RETRIEVE` shows the last Salesforce Core + Vlocity retrieve/export duration. The first cycle creates the baseline and shows `STATUS: BASELINE CREATED`; later refreshes show added, modified, deleted, or renamed files. Full errors and Vlocity warnings are wrapped in a detail section and automatically pause UI repainting so the text can be selected/copied.
+
+For Salesforce Core changes, the monitor queries the org metadata APIs to enrich each row with `LastModifiedBy.Name` and `LastModifiedDate`. For Vlocity changes, it now shares the Vlocity DataPack query catalog used by `sf metadelta find`, so paths such as `vlocity/Promotion/<GlobalKey>/...` are resolved against the parent DataPack record by `Name`, `Id`, or namespaced `GlobalKey__c` when available. This improves the modifier shown in the dashboard and in the change log instead of falling back to `N/A` for many Vlocity DataPack files.
 
 When `--scope-xml` or `--scope-yaml` is present, the dashboard scope label reflects the custom scope: `SALESFORCE-CUSTOM`, `VLOCITY-CUSTOM`, or `ALL-CUSTOM`. The XML/YAML paths can use any filename and are resolved relative to the directory where you start the command, before the monitor changes into `.metadelta/monitor/<orgAlias>/`.
 
@@ -443,7 +446,13 @@ sf metadelta monitor run --org DEV --scope salesforce
 
 `RECENT CHANGES` is cumulative within the active terminal session. Across restarts, the Git baseline and snapshots are preserved under `.metadelta/monitor/<orgAlias>/.metadelta-monitor/`, so the next run continues from the last baseline instead of starting from scratch. A persistent append-only change log is written to `.metadelta/monitor/<orgAlias>/change-log.jsonl`. It records `SESSION_STARTED`, `CHANGE_DETECTED`, and `SESSION_ENDED` events with the component type, component name, action, detection time, last modified date, and modifier when available. Vlocity files named `*_SampleInputJson.json` are ignored by the monitor because they are sample payloads and can produce noisy JSON parsing failures.
 
-> **Monitor persistence and scoped manifests (v0.11.10):** `sf metadelta monitor run` preserves snapshots, Git baseline, and `change-log.jsonl` under `.metadelta/monitor/<orgAlias>/`. Use `--scope-xml` and/or `--scope-yaml` to monitor only the components listed in a Core XML or Vlocity YAML manifest.
+To export the accumulated persistent log to CSV when the monitor exits, use `--export-csv`. The export includes session and change events in stable columns such as `event`, `org`, `scope`, `source`, `action`, `type`, `component`, `file`, `detectedAt`, `lastModifiedDate`, `lastModifiedBy`, `startedAt`, `endedAt`, `exitCode`, and `reason`.
+
+```bash
+sf metadelta monitor run --org DEV --export-csv reports/metadelta-monitor.csv
+```
+
+> **Monitor persistence, scoped manifests, Vlocity enrichment, and CSV export (v0.11.11):** `sf metadelta monitor run` preserves snapshots, Git baseline, and `change-log.jsonl` under `.metadelta/monitor/<orgAlias>/`. Use `--scope-xml` and/or `--scope-yaml` to monitor only the components listed in a Core XML or Vlocity YAML manifest. Use `--export-csv` to produce an audit-friendly CSV copy of the persistent log when the command exits.
 
 ### `task record` / `task play` command
 
@@ -728,7 +737,7 @@ Metadelta es un plugin personalizado de Salesforce CLI que ofrece trece familias
 * `sf metadelta access` exporta aliases, captura auth URLs cifradas y restaura accesos de forma segura entre Windows/Linux/WSL con validación MFA.
 * `sf metadelta security users` lee una matriz maestra de seguridad y una lista de usuarios objetivo, resuelve IDs requeridos en la org, genera CSVs listos para Bulk API para roles/PSG/grupos y opcionalmente aplica los cambios o genera una matrix de estado actual con `--validate`, y compara localmente ese archivo contra la matrix maestra con `--compare`.
 * `sf metadelta initspace` prepara un workspace local de Salesforce creando la estructura base de carpetas y los archivos semilla requeridos por el plugin.
-* `sf metadelta monitor run` inicia un monitor de terminal para detectar drift de metadatos Salesforce Core y Vlocity usando snapshots locales, Git local como motor de diff, manifiestos XML/YAML opcionales para scope específico y un log persistente JSONL.
+* `sf metadelta monitor run` inicia un monitor de terminal para detectar drift de metadatos Salesforce Core y Vlocity usando snapshots locales, Git local como motor de diff, manifiestos XML/YAML opcionales para scope específico, enriquecimiento de modificador Vlocity, log persistente JSONL y exportación CSV opcional.
 * `sf metadelta task record` y `sf metadelta task play` graban/reproducen tareas de Salesforce con Playwright, estabilizadores automáticos de recuperación, reproducción sobre `.metadelta.*` y diagnósticos orquestados.
 * `sf metadelta cleanps` genera una copia depurada de un permission set conservando solo los nodos que coincidan con un fragmento o con una lista permitida.
 * `sf metadelta findtest` revisa las clases Apex dentro de un proyecto SFDX local, confirma la presencia de sus clases de prueba correspondientes y puede validar `package.xml` existentes antes de un despliegue. Los manifiestos generados o actualizados usan la versión de API que reporte la org de destino cuando esté disponible.
@@ -1117,9 +1126,12 @@ Opciones:
 | `--scope` | Fuente de metadata a monitorear: `all`, `salesforce` o `vlocity`. | `all` |
 | `--scope-xml` | Ruta a un `package.xml` de Salesforce Core. Cuando se indica, el monitor recupera y observa solo los componentes Core listados en ese manifest. | Ninguno |
 | `--scope-yaml` | Ruta a un job/manifest YAML de Vlocity. Cuando se indica, el monitor exporta y observa solo los DataPacks listados en ese archivo. | Ninguno |
+| `--export-csv` | Ruta donde se debe exportar el `change-log.jsonl` persistente como CSV cuando el monitor sale. La ruta se resuelve desde el directorio donde se inició el comando. | Ninguno |
 | `--once` | Ejecuta un solo ciclo de refresh y sale. Útil para validación. | `false` |
 
 El monitor primero crea y entra en `.metadelta/monitor/<aliasOrg>/`. Dentro de esa carpeta mantiene `.metadelta-monitor/`, recupera el snapshot actual de metadatos, inicializa o reutiliza un repositorio Git local como motor de diff y refresca cada cinco minutos. `NEXT` muestra la hora exacta del próximo refresh en vez de repintar un countdown, y `RETRIEVE` muestra la duración del último retrieve/export Salesforce Core + Vlocity. El primer ciclo crea la línea base y muestra `STATUS: BASELINE CREATED`; los siguientes refresh muestran archivos agregados, modificados, eliminados o renombrados. Los errores completos y avisos de Vlocity se muestran envueltos en una sección de detalle y pausan automáticamente el repintado de la UI para poder seleccionar/copiar el texto.
+
+Para cambios Salesforce Core, el monitor consulta las APIs de metadata del org para enriquecer cada fila con `LastModifiedBy.Name` y `LastModifiedDate`. Para cambios Vlocity, ahora comparte el catálogo de queries DataPack usado por `sf metadelta find`, por lo que rutas como `vlocity/Promotion/<GlobalKey>/...` se resuelven contra el DataPack padre por `Name`, `Id` o el campo namespaced `GlobalKey__c` cuando esté disponible. Esto mejora el modificador mostrado en el dashboard y en el log, evitando caer en `N/A` para muchos archivos DataPack Vlocity.
 
 Cuando `--scope-xml` o `--scope-yaml` está presente, el dashboard muestra el scope custom correspondiente: `SALESFORCE-CUSTOM`, `VLOCITY-CUSTOM` o `ALL-CUSTOM`. Las rutas XML/YAML pueden tener cualquier nombre de archivo y se resuelven de forma relativa al directorio donde inicias el comando, antes de que el monitor cambie a `.metadelta/monitor/<aliasOrg>/`.
 
@@ -1149,7 +1161,13 @@ sf metadelta monitor run --org DEV --scope salesforce
 
 `RECENT CHANGES` es acumulativo dentro de la sesión activa de terminal. Entre ejecuciones, el baseline Git y los snapshots se preservan en `.metadelta/monitor/<aliasOrg>/.metadelta-monitor/`, por lo que el siguiente arranque continúa desde la última línea base en vez de iniciar desde cero. Además, se escribe un log persistente append-only en `.metadelta/monitor/<aliasOrg>/change-log.jsonl`. Este log registra eventos `SESSION_STARTED`, `CHANGE_DETECTED` y `SESSION_ENDED` con tipo de componente, nombre de componente, acción, hora de detección, fecha de última modificación y modificador cuando estén disponibles. Los archivos Vlocity `*_SampleInputJson.json` se ignoran porque son payloads de ejemplo y pueden generar ruido por errores de parsing JSON.
 
-> **Persistencia y manifests con scope en monitor (v0.11.10):** `sf metadelta monitor run` preserva snapshots, baseline Git y `change-log.jsonl` en `.metadelta/monitor/<aliasOrg>/`. Usa `--scope-xml` y/o `--scope-yaml` para monitorear solo los componentes indicados en un manifest XML Core o YAML Vlocity.
+Para exportar el log persistente acumulado a CSV cuando el monitor sale, usa `--export-csv`. La exportación incluye eventos de sesión y cambios en columnas estables como `event`, `org`, `scope`, `source`, `action`, `type`, `component`, `file`, `detectedAt`, `lastModifiedDate`, `lastModifiedBy`, `startedAt`, `endedAt`, `exitCode` y `reason`.
+
+```bash
+sf metadelta monitor run --org DEV --export-csv reports/metadelta-monitor.csv
+```
+
+> **Persistencia, manifests con scope, enriquecimiento Vlocity y exportación CSV en monitor (v0.11.11):** `sf metadelta monitor run` preserva snapshots, baseline Git y `change-log.jsonl` en `.metadelta/monitor/<aliasOrg>/`. Usa `--scope-xml` y/o `--scope-yaml` para monitorear solo los componentes indicados en un manifest XML Core o YAML Vlocity. Usa `--export-csv` para producir una copia CSV del log persistente al salir del comando.
 
 ### Comando `task record` / `task play`
 

--- a/lib/commands/metadelta/monitor/run.js
+++ b/lib/commands/metadelta/monitor/run.js
@@ -6,7 +6,7 @@ import { initGit, hasBaseline, createBaseline, parseDiff, diffSummary, updateBas
 import { normalizeTree } from '../../../utils/monitor/normalizer.js';
 import { retrieveSalesforceCore, exportVlocity } from '../../../utils/monitor/retriever.js';
 import { enrichChanges } from '../../../utils/monitor/metadata.js';
-import { appendChangeLogEntries, appendSessionEnded, appendSessionStarted } from '../../../utils/monitor/changeLog.js';
+import { appendChangeLogEntries, appendSessionEnded, appendSessionStarted, exportChangeLogToCsv } from '../../../utils/monitor/changeLog.js';
 import { MonitorUi } from '../../../utils/monitor/ui.js';
 import { isIgnoredMonitorFile } from '../../../utils/monitor/ignore.js';
 class MonitorRun extends Command {
@@ -32,6 +32,7 @@ class MonitorRun extends Command {
         }),
         'scope-xml': Flags.string({ summary: 'Path to a Salesforce Core package.xml used to monitor only those components' }),
         'scope-yaml': Flags.string({ summary: 'Path to a Vlocity YAML manifest used to monitor only those DataPacks' }),
+        'export-csv': Flags.string({ summary: 'Export the persistent monitor change log to this CSV file when the command exits' }),
         once: Flags.boolean({ summary: 'Run one refresh cycle and exit after cleanup. Useful for validation.' }),
     };
     async run() {
@@ -44,6 +45,7 @@ class MonitorRun extends Command {
         fs.mkdirSync(commandRoot, { recursive: true });
         process.chdir(commandRoot);
         const changeLogPath = path.join(commandRoot, 'change-log.jsonl');
+        const csvExportPath = flags['export-csv'] ? path.resolve(launchRoot, flags['export-csv']) : undefined;
         const intervalMs = Math.max(1, flags.interval) * 60 * 1000;
         const paths = createMonitorWorkspace(process.cwd(), orgAlias);
         let scope = resolveEffectiveScope(flags.scope, { scopedXmlPath, scopedYamlPath });
@@ -69,6 +71,9 @@ class MonitorRun extends Command {
                 exitCode: code,
                 reason,
             });
+            if (csvExportPath) {
+                exportChangeLogToCsv(changeLogPath, csvExportPath);
+            }
         };
         const scheduleNextRefresh = () => {
             if (flags.once || !ui || exiting) {

--- a/lib/utils/monitor/changeLog.js
+++ b/lib/utils/monitor/changeLog.js
@@ -39,7 +39,62 @@ export function appendChangeLogEntries(logPath, rows, { orgAlias, detectedAt }) 
     }));
     fs.appendFileSync(logPath, `${entries.join('\n')}\n`, 'utf8');
 }
+export function exportChangeLogToCsv(logPath, csvPath) {
+    const entries = readChangeLogEntries(logPath);
+    const columns = [
+        'event',
+        'org',
+        'scope',
+        'source',
+        'action',
+        'type',
+        'component',
+        'file',
+        'previousFile',
+        'detectedAt',
+        'lastModifiedDate',
+        'lastModifiedBy',
+        'startedAt',
+        'endedAt',
+        'exitCode',
+        'reason',
+    ];
+    const lines = [
+        columns.join(','),
+        ...entries.map((entry) => columns.map((column) => csvValue(entry[column])).join(',')),
+    ];
+    fs.mkdirSync(path.dirname(csvPath), { recursive: true });
+    fs.writeFileSync(csvPath, `${lines.join('\n')}\n`, 'utf8');
+    return { entries: entries.length, csvPath };
+}
 function appendLogEntry(logPath, entry) {
     fs.mkdirSync(path.dirname(logPath), { recursive: true });
     fs.appendFileSync(logPath, `${JSON.stringify(entry)}\n`, 'utf8');
+}
+function readChangeLogEntries(logPath) {
+    if (!fs.existsSync(logPath)) {
+        return [];
+    }
+    return fs.readFileSync(logPath, 'utf8')
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .flatMap((line) => {
+        try {
+            return [JSON.parse(line)];
+        }
+        catch {
+            return [];
+        }
+    });
+}
+function csvValue(value) {
+    if (value === undefined || value === null) {
+        return '';
+    }
+    const text = String(value);
+    if (!/[",\r\n]/.test(text)) {
+        return text;
+    }
+    return `"${text.replace(/"/g, '""')}"`;
 }

--- a/lib/utils/monitor/metadata.js
+++ b/lib/utils/monitor/metadata.js
@@ -17,9 +17,81 @@ const pathTypeMap = [
     { pattern: /(^|\/)FlexCard\//, type: 'FlexCard', field: 'Name', source: 'vlocity' },
     { pattern: /(^|\/)EPC\//, type: 'EPC', field: 'Name', source: 'vlocity' },
 ];
+const vlocityDatapackQueries = {
+    AttributeAssignmentRule: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__AttributeAssignmentRule__c',
+    AttributeCategory: 'SELECT Id, Name, %vlocity_namespace%__Code__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__AttributeCategory__c',
+    CalculationMatrix: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__CalculationMatrix__c',
+    CalculationProcedure: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__CalculationProcedure__c',
+    Catalog: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__Catalog__c',
+    ContextAction: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ContextAction__c',
+    ContextDimension: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ContextDimension__c',
+    ContextScope: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ContextScope__c',
+    ContractType: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ContractType__c',
+    DataRaptor: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__DRBundle__c WHERE %vlocity_namespace%__Type__c != \'Migration\'',
+    DocumentClause: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__DocumentClause__c',
+    DocumentTemplate: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__DocumentTemplate__c',
+    EntityFilter: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__EntityFilter__c',
+    IntegrationProcedure: 'SELECT Id, %vlocity_namespace%__Type__c, %vlocity_namespace%__SubType__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__OmniScript__c WHERE %vlocity_namespace%__IsActive__c = true AND %vlocity_namespace%__IsProcedure__c = true',
+    InterfaceImplementation: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__InterfaceImplementation__c',
+    ItemImplementation: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ItemImplementation__c',
+    ManualQueue: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ManualQueue__c',
+    ObjectClass: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ObjectClass__c',
+    ObjectContextRule: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ObjectRuleAssignment__c',
+    ObjectLayout: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ObjectLayout__c',
+    OmniScript: 'SELECT Id, %vlocity_namespace%__Type__c, %vlocity_namespace%__SubType__c, %vlocity_namespace%__Language__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__OmniScript__c WHERE %vlocity_namespace%__IsActive__c = true AND %vlocity_namespace%__IsProcedure__c = false',
+    OrchestrationDependencyDefinition: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__OrchestrationDependencyDefinition__c',
+    OrchestrationItemDefinition: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__OrchestrationItemDefinition__c',
+    OrchestrationPlanDefinition: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__OrchestrationPlanDefinition__c',
+    PriceList: 'SELECT Id, Name, %vlocity_namespace%__Code__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__PriceList__c',
+    Pricebook2: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM Pricebook2',
+    PricingPlan: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__PricingPlan__c',
+    PricingVariable: 'SELECT Id, Name, %vlocity_namespace%__Code__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__PricingVariable__c',
+    Product2: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM Product2',
+    Promotion: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__Promotion__c',
+    QueryBuilder: 'SELECT Id, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__QueryBuilder__c',
+    Rule: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__Rule__c',
+    StoryObjectConfiguration: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__StoryObjectConfiguration__c',
+    System: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__System__c',
+    TimePlan: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__TimePlan__c',
+    TimePolicy: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__TimePolicy__c',
+    UIFacet: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__UIFacet__c',
+    UISection: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__UISection__c',
+    VlocityAction: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityAction__c WHERE %vlocity_namespace%__IsActive__c = true',
+    VlocityCard: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityCard__c WHERE %vlocity_namespace%__Active__c = true',
+    VlocityFunction: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityFunction__c',
+    VlocityPicklist: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__Picklist__c',
+    VlocitySearchWidgetSetup: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocitySearchWidgetSetup__c',
+    VlocityStateModel: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityStateModel__c',
+    VlocityUILayout: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityUILayout__c WHERE %vlocity_namespace%__Active__c = true',
+    VlocityUITemplate: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityUITemplate__c WHERE %vlocity_namespace%__Active__c = true',
+    VqMachine: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VqMachine__c',
+    VqResource: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VqResource__c',
+};
+const globalKeyTypes = new Set([
+    'ContextAction',
+    'ContextDimension',
+    'ContextScope',
+    'EntityFilter',
+    'ObjectClass',
+    'ObjectLayout',
+    'OrchestrationDependencyDefinition',
+    'Product2',
+    'Promotion',
+    'Rule',
+    'TimePlan',
+    'TimePolicy',
+    'UIFacet',
+    'UISection',
+    'VlocityFunction',
+    'VlocityPicklist',
+]);
+const codeTypes = new Set(['AttributeCategory', 'PriceList', 'PricingVariable']);
 export function classifyChange(file) {
     const normalized = file.split(path.sep).join('/');
     const mapping = pathTypeMap.find((item) => item.pattern.test(normalized));
+    const vlocityPathInfo = getVlocityPathInfo(normalized);
+    const source = mapping?.source ?? (vlocityPathInfo ? 'vlocity' : 'salesforce');
+    const type = mapping?.type ?? vlocityPathInfo?.type ?? inferTypeFromPath(normalized);
     const baseName = mapping?.source === 'vlocity' ? vlocityMemberName(normalized, mapping.type) : path.basename(file)
         .replace(/\.xml$/i, '')
         .replace(/\.[^.]+-meta$/i, '')
@@ -28,9 +100,9 @@ export function classifyChange(file) {
         .replace(/\.[^.]+$/i, '');
     return {
         file,
-        type: mapping?.type ?? inferTypeFromPath(normalized),
-        source: mapping?.source ?? (normalized.includes('/vlocity/') ? 'vlocity' : 'salesforce'),
-        memberName: baseName,
+        type,
+        source,
+        memberName: source === 'vlocity' ? (vlocityPathInfo?.memberName ?? baseName) : baseName,
         queryField: mapping?.field ?? 'Name',
     };
 }
@@ -41,6 +113,17 @@ function vlocityMemberName(file, type) {
         return parts[typeIndex + 1];
     }
     return path.basename(file).replace(/_AllRelationshipKeys\.json$/i, '').replace(/\.[^.]+$/i, '');
+}
+function getVlocityPathInfo(file) {
+    const parts = file.split('/');
+    const index = parts.findIndex((part) => part.toLowerCase() === 'vlocity');
+    if (index < 0 || !parts[index + 1]) {
+        return null;
+    }
+    return {
+        type: parts[index + 1],
+        memberName: parts[index + 2] ?? path.basename(file).replace(/_AllRelationshipKeys\.json$/i, '').replace(/\.[^.]+$/i, ''),
+    };
 }
 export async function enrichChanges(changes, orgAlias, gitRoot, getDiffSummary) {
     const rows = [];
@@ -145,50 +228,75 @@ function buildVlocityQueries(classified, namespace) {
     const typeValue = omniNameParts[0] ?? name;
     const subTypeValue = omniNameParts.slice(1, -1).join('_') || omniNameParts[1] || '';
     const languageValue = omniNameParts.at(-1) || '';
+    const queries = [];
+    const findQuery = buildFindVlocityQuery(classified, namespace);
+    if (findQuery) {
+        queries.push(findQuery);
+    }
     if (classified.type === 'DRBundle') {
-        return ns
-            ? [
-                // Same base query used by metadelta find for DataRaptor.
-                `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM ${ns}DRBundle__c WHERE ${ns}Type__c != 'Migration' AND Name = '${name}' LIMIT 1`,
-            ]
-            : [];
+        if (ns) {
+            // Same base query used by metadelta find for DataRaptor.
+            queries.push(`SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM ${ns}DRBundle__c WHERE ${ns}Type__c != 'Migration' AND Name = '${name}' LIMIT 1`);
+        }
     }
     if (classified.type === 'FlexCard') {
-        return [
-            ...(ns
-                ? [
-                    // Same base query used by metadelta find for VlocityCard/FlexCard.
-                    `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM ${ns}VlocityCard__c WHERE ${ns}Active__c = true AND Name = '${name}' LIMIT 1`,
-                ]
-                : []),
-            `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniUiCard WHERE Name = '${name}' LIMIT 1`,
-        ];
+        queries.push(...(ns
+            ? [
+                // Same base query used by metadelta find for VlocityCard/FlexCard.
+                `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM ${ns}VlocityCard__c WHERE ${ns}Active__c = true AND Name = '${name}' LIMIT 1`,
+            ]
+            : []), `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniUiCard WHERE Name = '${name}' LIMIT 1`);
     }
     if (classified.type === 'IntegrationProcedure') {
-        return [
-            ...(ns
-                ? [
-                    // Same base query used by metadelta find for IntegrationProcedure.
-                    `SELECT Id, ${ns}Type__c, ${ns}SubType__c, LastModifiedDate, LastModifiedBy.Name FROM ${ns}OmniScript__c WHERE ${ns}IsActive__c = true AND ${ns}IsProcedure__c = true AND ${ns}Type__c = '${typeValue}' AND ${ns}SubType__c = '${subTypeValue}' LIMIT 1`,
-                ]
-                : []),
-            `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Type = '${typeValue}' AND SubType = '${subTypeValue}' AND IsActive = true LIMIT 1`,
-            `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Name = '${name}' LIMIT 1`,
-        ];
+        queries.push(...(ns
+            ? [
+                // Same base query used by metadelta find for IntegrationProcedure.
+                `SELECT Id, ${ns}Type__c, ${ns}SubType__c, LastModifiedDate, LastModifiedBy.Name FROM ${ns}OmniScript__c WHERE ${ns}IsActive__c = true AND ${ns}IsProcedure__c = true AND ${ns}Type__c = '${typeValue}' AND ${ns}SubType__c = '${subTypeValue}' LIMIT 1`,
+            ]
+            : []), `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Type = '${typeValue}' AND SubType = '${subTypeValue}' AND IsActive = true LIMIT 1`, `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Name = '${name}' LIMIT 1`);
     }
     if (classified.type === 'OmniProcess') {
-        return [
-            ...(ns
-                ? [
-                    // Same base query used by metadelta find for OmniScript.
-                    `SELECT Id, ${ns}Type__c, ${ns}SubType__c, ${ns}Language__c, LastModifiedDate, LastModifiedBy.Name FROM ${ns}OmniScript__c WHERE ${ns}IsActive__c = true AND ${ns}IsProcedure__c = false AND ${ns}Type__c = '${typeValue}' AND ${ns}SubType__c = '${subTypeValue}' AND ${ns}Language__c = '${languageValue}' LIMIT 1`,
-                ]
-                : []),
-            `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Type = '${typeValue}' AND SubType = '${subTypeValue}' AND Language = '${languageValue}' AND IsActive = true LIMIT 1`,
-            `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Name = '${name}' LIMIT 1`,
-        ];
+        queries.push(...(ns
+            ? [
+                // Same base query used by metadelta find for OmniScript.
+                `SELECT Id, ${ns}Type__c, ${ns}SubType__c, ${ns}Language__c, LastModifiedDate, LastModifiedBy.Name FROM ${ns}OmniScript__c WHERE ${ns}IsActive__c = true AND ${ns}IsProcedure__c = false AND ${ns}Type__c = '${typeValue}' AND ${ns}SubType__c = '${subTypeValue}' AND ${ns}Language__c = '${languageValue}' LIMIT 1`,
+            ]
+            : []), `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Type = '${typeValue}' AND SubType = '${subTypeValue}' AND Language = '${languageValue}' AND IsActive = true LIMIT 1`, `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Name = '${name}' LIMIT 1`);
     }
-    return [];
+    return Array.from(new Set(queries));
+}
+function buildFindVlocityQuery(classified, namespace) {
+    const template = vlocityDatapackQueries[classified.type];
+    if (!template) {
+        return null;
+    }
+    if (!namespace && template.includes('%vlocity_namespace%')) {
+        return null;
+    }
+    const query = template.replace(/%vlocity_namespace%/g, namespace);
+    const filters = buildFindVlocityFilters(classified, namespace);
+    if (filters.length === 0) {
+        return `${query} LIMIT 1`;
+    }
+    const operator = /\bwhere\b/i.test(query) ? 'AND' : 'WHERE';
+    return `${query} ${operator} (${filters.join(' OR ')}) LIMIT 1`;
+}
+function buildFindVlocityFilters(classified, namespace) {
+    const name = soql(classified.memberName);
+    const ns = namespace ? `${namespace}__` : '';
+    const filters = classified.type === 'QueryBuilder'
+        ? [`Id = '${name}'`]
+        : [`Name = '${name}'`, `Id = '${name}'`];
+    if (globalKeyTypes.has(classified.type) && ns) {
+        filters.push(`${ns}GlobalKey__c = '${name}'`);
+    }
+    if (codeTypes.has(classified.type) && ns) {
+        filters.push(`${ns}Code__c = '${name}'`);
+    }
+    if (classified.type === 'Pricebook2' || classified.type === 'PricingPlan') {
+        filters.push(`Name = '${soql(classified.memberName.replace(/-/g, ' '))}'`);
+    }
+    return Array.from(new Set(filters));
 }
 function soql(value) {
     return String(value ?? '').replace(/\\/g, '\\\\').replace(/'/g, "\\'");

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -691,6 +691,13 @@
           "multiple": false,
           "type": "option"
         },
+        "export-csv": {
+          "name": "export-csv",
+          "summary": "Export the persistent monitor change log to this CSV file when the command exits",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "once": {
           "name": "once",
           "summary": "Run one refresh cycle and exit after cleanup. Useful for validation.",
@@ -929,5 +936,5 @@
       ]
     }
   },
-  "version": "0.11.10"
+  "version": "0.11.11"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nervill/metadelta",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nervill/metadelta",
-      "version": "0.11.10",
+      "version": "0.11.11",
       "license": "MIT",
       "dependencies": {
         "@oclif/core": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nervill/metadelta",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "description": "Salesforce CLI plugin to find recent metadata changes in an org",
   "type": "module",
   "main": "lib/index.js",

--- a/src/commands/metadelta/monitor/run.js
+++ b/src/commands/metadelta/monitor/run.js
@@ -9,7 +9,7 @@ import {initGit, hasBaseline, createBaseline, parseDiff, diffSummary, updateBase
 import {normalizeTree} from '../../../utils/monitor/normalizer.js';
 import {retrieveSalesforceCore, exportVlocity} from '../../../utils/monitor/retriever.js';
 import {enrichChanges} from '../../../utils/monitor/metadata.js';
-import {appendChangeLogEntries, appendSessionEnded, appendSessionStarted} from '../../../utils/monitor/changeLog.js';
+import {appendChangeLogEntries, appendSessionEnded, appendSessionStarted, exportChangeLogToCsv} from '../../../utils/monitor/changeLog.js';
 import {MonitorUi} from '../../../utils/monitor/ui.js';
 import {isIgnoredMonitorFile} from '../../../utils/monitor/ignore.js';
 
@@ -38,6 +38,7 @@ class MonitorRun extends Command {
     }),
     'scope-xml': Flags.string({summary: 'Path to a Salesforce Core package.xml used to monitor only those components'}),
     'scope-yaml': Flags.string({summary: 'Path to a Vlocity YAML manifest used to monitor only those DataPacks'}),
+    'export-csv': Flags.string({summary: 'Export the persistent monitor change log to this CSV file when the command exits'}),
     once: Flags.boolean({summary: 'Run one refresh cycle and exit after cleanup. Useful for validation.'}),
   };
 
@@ -51,6 +52,7 @@ class MonitorRun extends Command {
     fs.mkdirSync(commandRoot, {recursive: true});
     process.chdir(commandRoot);
     const changeLogPath = path.join(commandRoot, 'change-log.jsonl');
+    const csvExportPath = flags['export-csv'] ? path.resolve(launchRoot, flags['export-csv']) : undefined;
     const intervalMs = Math.max(1, flags.interval) * 60 * 1000;
     const paths = createMonitorWorkspace(process.cwd(), orgAlias);
     let scope = resolveEffectiveScope(flags.scope, {scopedXmlPath, scopedYamlPath});
@@ -77,6 +79,9 @@ class MonitorRun extends Command {
         exitCode: code,
         reason,
       });
+      if (csvExportPath) {
+        exportChangeLogToCsv(changeLogPath, csvExportPath);
+      }
     };
 
     const scheduleNextRefresh = () => {

--- a/src/utils/monitor/changeLog.js
+++ b/src/utils/monitor/changeLog.js
@@ -43,7 +43,64 @@ export function appendChangeLogEntries(logPath, rows, {orgAlias, detectedAt}) {
   fs.appendFileSync(logPath, `${entries.join('\n')}\n`, 'utf8');
 }
 
+export function exportChangeLogToCsv(logPath, csvPath) {
+  const entries = readChangeLogEntries(logPath);
+  const columns = [
+    'event',
+    'org',
+    'scope',
+    'source',
+    'action',
+    'type',
+    'component',
+    'file',
+    'previousFile',
+    'detectedAt',
+    'lastModifiedDate',
+    'lastModifiedBy',
+    'startedAt',
+    'endedAt',
+    'exitCode',
+    'reason',
+  ];
+  const lines = [
+    columns.join(','),
+    ...entries.map((entry) => columns.map((column) => csvValue(entry[column])).join(',')),
+  ];
+  fs.mkdirSync(path.dirname(csvPath), {recursive: true});
+  fs.writeFileSync(csvPath, `${lines.join('\n')}\n`, 'utf8');
+  return {entries: entries.length, csvPath};
+}
+
 function appendLogEntry(logPath, entry) {
   fs.mkdirSync(path.dirname(logPath), {recursive: true});
   fs.appendFileSync(logPath, `${JSON.stringify(entry)}\n`, 'utf8');
+}
+
+function readChangeLogEntries(logPath) {
+  if (!fs.existsSync(logPath)) {
+    return [];
+  }
+  return fs.readFileSync(logPath, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line)];
+      } catch {
+        return [];
+      }
+    });
+}
+
+function csvValue(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  const text = String(value);
+  if (!/[",\r\n]/.test(text)) {
+    return text;
+  }
+  return `"${text.replace(/"/g, '""')}"`;
 }

--- a/src/utils/monitor/metadata.js
+++ b/src/utils/monitor/metadata.js
@@ -19,9 +19,84 @@ const pathTypeMap = [
   {pattern: /(^|\/)EPC\//, type: 'EPC', field: 'Name', source: 'vlocity'},
 ];
 
+const vlocityDatapackQueries = {
+  AttributeAssignmentRule: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__AttributeAssignmentRule__c',
+  AttributeCategory: 'SELECT Id, Name, %vlocity_namespace%__Code__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__AttributeCategory__c',
+  CalculationMatrix: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__CalculationMatrix__c',
+  CalculationProcedure: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__CalculationProcedure__c',
+  Catalog: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__Catalog__c',
+  ContextAction: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ContextAction__c',
+  ContextDimension: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ContextDimension__c',
+  ContextScope: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ContextScope__c',
+  ContractType: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ContractType__c',
+  DataRaptor: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__DRBundle__c WHERE %vlocity_namespace%__Type__c != \'Migration\'',
+  DocumentClause: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__DocumentClause__c',
+  DocumentTemplate: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__DocumentTemplate__c',
+  EntityFilter: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__EntityFilter__c',
+  IntegrationProcedure: 'SELECT Id, %vlocity_namespace%__Type__c, %vlocity_namespace%__SubType__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__OmniScript__c WHERE %vlocity_namespace%__IsActive__c = true AND %vlocity_namespace%__IsProcedure__c = true',
+  InterfaceImplementation: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__InterfaceImplementation__c',
+  ItemImplementation: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ItemImplementation__c',
+  ManualQueue: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ManualQueue__c',
+  ObjectClass: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ObjectClass__c',
+  ObjectContextRule: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ObjectRuleAssignment__c',
+  ObjectLayout: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__ObjectLayout__c',
+  OmniScript: 'SELECT Id, %vlocity_namespace%__Type__c, %vlocity_namespace%__SubType__c, %vlocity_namespace%__Language__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__OmniScript__c WHERE %vlocity_namespace%__IsActive__c = true AND %vlocity_namespace%__IsProcedure__c = false',
+  OrchestrationDependencyDefinition: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__OrchestrationDependencyDefinition__c',
+  OrchestrationItemDefinition: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__OrchestrationItemDefinition__c',
+  OrchestrationPlanDefinition: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__OrchestrationPlanDefinition__c',
+  PriceList: 'SELECT Id, Name, %vlocity_namespace%__Code__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__PriceList__c',
+  Pricebook2: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM Pricebook2',
+  PricingPlan: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__PricingPlan__c',
+  PricingVariable: 'SELECT Id, Name, %vlocity_namespace%__Code__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__PricingVariable__c',
+  Product2: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM Product2',
+  Promotion: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__Promotion__c',
+  QueryBuilder: 'SELECT Id, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__QueryBuilder__c',
+  Rule: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__Rule__c',
+  StoryObjectConfiguration: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__StoryObjectConfiguration__c',
+  System: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__System__c',
+  TimePlan: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__TimePlan__c',
+  TimePolicy: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__TimePolicy__c',
+  UIFacet: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__UIFacet__c',
+  UISection: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__UISection__c',
+  VlocityAction: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityAction__c WHERE %vlocity_namespace%__IsActive__c = true',
+  VlocityCard: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityCard__c WHERE %vlocity_namespace%__Active__c = true',
+  VlocityFunction: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityFunction__c',
+  VlocityPicklist: 'SELECT Id, Name, %vlocity_namespace%__GlobalKey__c, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__Picklist__c',
+  VlocitySearchWidgetSetup: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocitySearchWidgetSetup__c',
+  VlocityStateModel: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityStateModel__c',
+  VlocityUILayout: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityUILayout__c WHERE %vlocity_namespace%__Active__c = true',
+  VlocityUITemplate: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VlocityUITemplate__c WHERE %vlocity_namespace%__Active__c = true',
+  VqMachine: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VqMachine__c',
+  VqResource: 'SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM %vlocity_namespace%__VqResource__c',
+};
+
+const globalKeyTypes = new Set([
+  'ContextAction',
+  'ContextDimension',
+  'ContextScope',
+  'EntityFilter',
+  'ObjectClass',
+  'ObjectLayout',
+  'OrchestrationDependencyDefinition',
+  'Product2',
+  'Promotion',
+  'Rule',
+  'TimePlan',
+  'TimePolicy',
+  'UIFacet',
+  'UISection',
+  'VlocityFunction',
+  'VlocityPicklist',
+]);
+
+const codeTypes = new Set(['AttributeCategory', 'PriceList', 'PricingVariable']);
+
 export function classifyChange(file) {
   const normalized = file.split(path.sep).join('/');
   const mapping = pathTypeMap.find((item) => item.pattern.test(normalized));
+  const vlocityPathInfo = getVlocityPathInfo(normalized);
+  const source = mapping?.source ?? (vlocityPathInfo ? 'vlocity' : 'salesforce');
+  const type = mapping?.type ?? vlocityPathInfo?.type ?? inferTypeFromPath(normalized);
   const baseName = mapping?.source === 'vlocity' ? vlocityMemberName(normalized, mapping.type) : path.basename(file)
     .replace(/\.xml$/i, '')
     .replace(/\.[^.]+-meta$/i, '')
@@ -30,9 +105,9 @@ export function classifyChange(file) {
     .replace(/\.[^.]+$/i, '');
   return {
     file,
-    type: mapping?.type ?? inferTypeFromPath(normalized),
-    source: mapping?.source ?? (normalized.includes('/vlocity/') ? 'vlocity' : 'salesforce'),
-    memberName: baseName,
+    type,
+    source,
+    memberName: source === 'vlocity' ? (vlocityPathInfo?.memberName ?? baseName) : baseName,
     queryField: mapping?.field ?? 'Name',
   };
 }
@@ -44,6 +119,18 @@ function vlocityMemberName(file, type) {
     return parts[typeIndex + 1];
   }
   return path.basename(file).replace(/_AllRelationshipKeys\.json$/i, '').replace(/\.[^.]+$/i, '');
+}
+
+function getVlocityPathInfo(file) {
+  const parts = file.split('/');
+  const index = parts.findIndex((part) => part.toLowerCase() === 'vlocity');
+  if (index < 0 || !parts[index + 1]) {
+    return null;
+  }
+  return {
+    type: parts[index + 1],
+    memberName: parts[index + 2] ?? path.basename(file).replace(/_AllRelationshipKeys\.json$/i, '').replace(/\.[^.]+$/i, ''),
+  };
 }
 
 export async function enrichChanges(changes, orgAlias, gitRoot, getDiffSummary) {
@@ -151,17 +238,21 @@ function buildVlocityQueries(classified, namespace) {
   const typeValue = omniNameParts[0] ?? name;
   const subTypeValue = omniNameParts.slice(1, -1).join('_') || omniNameParts[1] || '';
   const languageValue = omniNameParts.at(-1) || '';
+  const queries = [];
+  const findQuery = buildFindVlocityQuery(classified, namespace);
+
+  if (findQuery) {
+    queries.push(findQuery);
+  }
 
   if (classified.type === 'DRBundle') {
-    return ns
-      ? [
-          // Same base query used by metadelta find for DataRaptor.
-          `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM ${ns}DRBundle__c WHERE ${ns}Type__c != 'Migration' AND Name = '${name}' LIMIT 1`,
-        ]
-      : [];
+    if (ns) {
+      // Same base query used by metadelta find for DataRaptor.
+      queries.push(`SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM ${ns}DRBundle__c WHERE ${ns}Type__c != 'Migration' AND Name = '${name}' LIMIT 1`);
+    }
   }
   if (classified.type === 'FlexCard') {
-    return [
+    queries.push(
       ...(ns
         ? [
             // Same base query used by metadelta find for VlocityCard/FlexCard.
@@ -169,10 +260,10 @@ function buildVlocityQueries(classified, namespace) {
           ]
         : []),
       `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniUiCard WHERE Name = '${name}' LIMIT 1`,
-    ];
+    );
   }
   if (classified.type === 'IntegrationProcedure') {
-    return [
+    queries.push(
       ...(ns
         ? [
             // Same base query used by metadelta find for IntegrationProcedure.
@@ -181,10 +272,10 @@ function buildVlocityQueries(classified, namespace) {
         : []),
       `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Type = '${typeValue}' AND SubType = '${subTypeValue}' AND IsActive = true LIMIT 1`,
       `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Name = '${name}' LIMIT 1`,
-    ];
+    );
   }
   if (classified.type === 'OmniProcess') {
-    return [
+    queries.push(
       ...(ns
         ? [
             // Same base query used by metadelta find for OmniScript.
@@ -193,9 +284,48 @@ function buildVlocityQueries(classified, namespace) {
         : []),
       `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Type = '${typeValue}' AND SubType = '${subTypeValue}' AND Language = '${languageValue}' AND IsActive = true LIMIT 1`,
       `SELECT Id, Name, LastModifiedDate, LastModifiedBy.Name FROM OmniProcess WHERE Name = '${name}' LIMIT 1`,
-    ];
+    );
   }
-  return [];
+
+  return Array.from(new Set(queries));
+}
+
+function buildFindVlocityQuery(classified, namespace) {
+  const template = vlocityDatapackQueries[classified.type];
+  if (!template) {
+    return null;
+  }
+  if (!namespace && template.includes('%vlocity_namespace%')) {
+    return null;
+  }
+
+  const query = template.replace(/%vlocity_namespace%/g, namespace);
+  const filters = buildFindVlocityFilters(classified, namespace);
+  if (filters.length === 0) {
+    return `${query} LIMIT 1`;
+  }
+  const operator = /\bwhere\b/i.test(query) ? 'AND' : 'WHERE';
+  return `${query} ${operator} (${filters.join(' OR ')}) LIMIT 1`;
+}
+
+function buildFindVlocityFilters(classified, namespace) {
+  const name = soql(classified.memberName);
+  const ns = namespace ? `${namespace}__` : '';
+  const filters = classified.type === 'QueryBuilder'
+    ? [`Id = '${name}'`]
+    : [`Name = '${name}'`, `Id = '${name}'`];
+
+  if (globalKeyTypes.has(classified.type) && ns) {
+    filters.push(`${ns}GlobalKey__c = '${name}'`);
+  }
+  if (codeTypes.has(classified.type) && ns) {
+    filters.push(`${ns}Code__c = '${name}'`);
+  }
+  if (classified.type === 'Pricebook2' || classified.type === 'PricingPlan') {
+    filters.push(`Name = '${soql(classified.memberName.replace(/-/g, ' '))}'`);
+  }
+
+  return Array.from(new Set(filters));
 }
 
 function soql(value) {

--- a/test/monitor-change-log-csv.test.js
+++ b/test/monitor-change-log-csv.test.js
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  appendChangeLogEntries,
+  appendSessionEnded,
+  appendSessionStarted,
+  exportChangeLogToCsv,
+} from '../src/utils/monitor/changeLog.js';
+
+test('exportChangeLogToCsv exports monitor JSONL events with stable CSV columns', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'metadelta-monitor-log-'));
+  const logPath = path.join(tmp, 'change-log.jsonl');
+  const csvPath = path.join(tmp, 'change-log.csv');
+
+  appendSessionStarted(logPath, {
+    orgAlias: 'Telecentro-qa',
+    scope: 'all-custom',
+    startedAt: '2026-06-26T22:02:51.033Z',
+  });
+  appendChangeLogEntries(logPath, [
+    {
+      source: 'vlocity',
+      action: 'MODIFIED',
+      type: 'Promotion',
+      memberName: 'Promo, Internet',
+      file: 'Telecentro-qa/current/vlocity/Promotion/abc/Promo.json',
+      lastModifiedDate: '2026-06-26T22:17:19.783Z',
+      user: 'Luis "QA" Ramírez',
+    },
+  ], {
+    orgAlias: 'Telecentro-qa',
+    detectedAt: '2026-06-26T22:17:19.783Z',
+  });
+  appendSessionEnded(logPath, {
+    orgAlias: 'Telecentro-qa',
+    scope: 'all-custom',
+    startedAt: '2026-06-26T22:02:51.033Z',
+    endedAt: '2026-06-26T23:34:02.985Z',
+    exitCode: 0,
+    reason: 'USER_EXIT',
+  });
+
+  const result = exportChangeLogToCsv(logPath, csvPath);
+  const csv = fs.readFileSync(csvPath, 'utf8');
+
+  assert.equal(result.entries, 3);
+  assert.match(csv, /^event,org,scope,source,action,type,component,file,previousFile,detectedAt,lastModifiedDate,lastModifiedBy,startedAt,endedAt,exitCode,reason\n/);
+  assert.match(csv, /CHANGE_DETECTED,Telecentro-qa,,vlocity,MODIFIED,Promotion,"Promo, Internet"/);
+  assert.match(csv, /"Luis ""QA"" Ramírez"/);
+  assert.match(csv, /SESSION_ENDED,Telecentro-qa,all-custom/);
+});


### PR DESCRIPTION
- Introduced `export-csv` flag to the monitor command for exporting change logs to CSV format.
- Implemented `exportChangeLogToCsv` function to convert JSONL change log entries to CSV.
- Enhanced `classifyChange` function to support new Vlocity datapack queries.
- Added unit tests for CSV export functionality to ensure correct output format and data integrity.
- Updated package version to 0.11.11.