### PR TITLE
Automate npm publishing with trusted OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,20 +7,27 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  build-and-package:
+  build-publish-and-release:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
@@ -31,11 +38,11 @@ jobs:
           npm version "$VERSION" --no-git-tag-version --allow-same-version
           echo "PKG_VERSION=$VERSION" >> $GITHUB_ENV
 
+      - name: Run tests
+        run: npm test
+
       - name: Build (compile TypeScript)
         run: npm run compile
-
-      - name: Generate manifest after build (while dependencies exist)
-        run: npm run manifest
 
       - name: Remove node_modules before packaging
         run: rm -rf node_modules
@@ -46,6 +53,9 @@ jobs:
           echo "TARBALL_NAME=$PKG" >> $GITHUB_ENV
           cp "$PKG" "metadelta-${PKG_VERSION}.tgz"
           echo "ALIAS_TARBALL_NAME=metadelta-${PKG_VERSION}.tgz" >> $GITHUB_ENV
+
+      - name: Publish to npm with trusted publishing
+        run: npm publish "$TARBALL_NAME" --access public
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## What changed

- Grants GitHub Actions the `id-token: write` permission required for npm trusted publishing.
- Moves the release job to Node.js 24 with `actions/checkout@v6` and `actions/setup-node@v6`.
- Disables package-manager caching for release builds.
- Runs the test suite before compilation and publication.
- Publishes the exact generated tarball to npm with public access.
- Keeps the existing GitHub Release and tarball attachment flow.
- Adds release concurrency protection and a 20-minute job timeout.
- Removes the redundant manifest step because `npm run compile` already generates it.

## Why

The repository previously created GitHub Releases from `v*` tags but did not synchronize those releases to npm. Trusted publishing uses short-lived OIDC credentials and avoids storing a long-lived npm write token in GitHub.

## User impact

After this PR is merged, pushing a new semantic version tag such as `v0.11.15` will install dependencies, align the package version to the tag, run tests, compile, package, publish to npm, and create the GitHub Release.

## npm configuration

The npm package now trusts `NerioVillalobos/plugin-metadelta` workflow `release.yml` for the `npm publish` action.

## Validation

- `git diff --check`
- Trusted Publisher connection confirmed in npm package settings
- Workflow scope manually reviewed
- Full Linux dependency installation, tests, and compilation will run in GitHub Actions